### PR TITLE
fix(inputs): `tsconfig_file` => `tsconfig` to match code/docs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
   output_dir:
     description: 'Output folder for the generated documentation'
     required: false
-  tsconfig_file:
+  tsconfig:
     description: 'The path to a tsconfig.json file. Defaults to ./tsconfig.json'
     required: false
   options:


### PR DESCRIPTION
Thanks for this action - it's been helpful in a few projects already!

Here's a small fix to inputs, aligning to the value that's in code ([`tsconfig`](https://github.com/erikyo/tsdoc-action/blob/master/src/index.ts#L97)).